### PR TITLE
Bump WebRTC to 137.0.0 and remove unsafe enum conformances

### DIFF
--- a/WebRTC-Demo-App/Sources/Extensions/RTCStates.swift
+++ b/WebRTC-Demo-App/Sources/Extensions/RTCStates.swift
@@ -9,8 +9,8 @@
 import Foundation
 import WebRTC
 
-extension RTCIceConnectionState: CustomStringConvertible {
-    public var description: String {
+extension RTCIceConnectionState {
+    var description: String {
         switch self {
         case .new:          return "new"
         case .checking:     return "checking"
@@ -24,9 +24,8 @@ extension RTCIceConnectionState: CustomStringConvertible {
         }
     }
 }
-
-extension RTCSignalingState: CustomStringConvertible {
-    public var description: String {
+extension RTCSignalingState {
+    var stringValue: String {
         switch self {
         case .stable:               return "stable"
         case .haveLocalOffer:       return "haveLocalOffer"
@@ -34,13 +33,13 @@ extension RTCSignalingState: CustomStringConvertible {
         case .haveRemoteOffer:      return "haveRemoteOffer"
         case .haveRemotePrAnswer:   return "haveRemotePrAnswer"
         case .closed:               return "closed"
-        @unknown default:   return "Unknown \(self.rawValue)"
+        @unknown default:           return "Unknown \(self.rawValue)"
         }
     }
 }
 
-extension RTCIceGatheringState: CustomStringConvertible {
-    public var description: String {
+extension RTCIceGatheringState {
+    var stringValue: String {
         switch self {
         case .new:          return "new"
         case .gathering:    return "gathering"
@@ -50,8 +49,8 @@ extension RTCIceGatheringState: CustomStringConvertible {
     }
 }
 
-extension RTCDataChannelState: CustomStringConvertible {
-    public var description: String {
+extension RTCDataChannelState {
+    var stringValue: String {
         switch self {
         case .connecting:   return "connecting"
         case .open:         return "open"
@@ -61,4 +60,3 @@ extension RTCDataChannelState: CustomStringConvertible {
         }
     }
 }
-

--- a/WebRTC-Demo-App/WebRTC-Demo.xcodeproj/project.pbxproj
+++ b/WebRTC-Demo-App/WebRTC-Demo.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 			repositoryURL = "https://github.com/stasel/WebRTC";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 125.0.0;
+				minimumVersion = 137.0.0;
 			};
 		};
 		2F2E228628E81A080026A8B5 /* XCRemoteSwiftPackageReference "Starscream" */ = {

--- a/WebRTC-Demo-App/WebRTC-Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebRTC-Demo-App/WebRTC-Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "1d23430878d9b5effb86fb818b19d2c0b9b5ad0c42acdd2eeb4314fd1f3be72f",
   "pins" : [
     {
       "identity" : "starscream",
@@ -14,10 +15,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC",
       "state" : {
-        "revision" : "463d4d2ec50920518f6569872d3b1ea4d187404a",
-        "version" : "121.0.0"
+        "revision" : "b85669f32ffb3f48ce3a8f18ad828c6f559a8a0c",
+        "version" : "137.0.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
Description of changes:
1. Avoid extending imported WebRTC enums with protocol conformance (CustomStringConvertible) to prevent future compatibility issues.
2. chore: bump WebRTC version to 137.0.0 to stay up to date with latest improvements and compatibility.

Testing:
Unit tests pass
Manually tested the application with the NodeJS Signaling Server, iOS - verified that we can see the media on both ends.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

